### PR TITLE
ci: extract rcodesign with --wildcards so GNU tar finds it on linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,10 @@ jobs:
           RC_VER="0.27.0"
           curl -fsSL -o rcodesign.tar.gz \
             "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RC_VER}/apple-codesign-${RC_VER}-x86_64-unknown-linux-musl.tar.gz"
-          tar -xzf rcodesign.tar.gz --strip-components=1 -C /usr/local/bin "*/rcodesign"
+          # GNU tar (Linux runners) needs --wildcards to treat */rcodesign as a
+          # glob; without it the pattern is matched literally and not found. (BSD
+          # tar on macOS globs by default, so this only fails on the CI runner.)
+          tar -xzf rcodesign.tar.gz --strip-components=1 -C /usr/local/bin --wildcards "*/rcodesign"
           rcodesign --version
 
       # Detect whether macOS signing secrets are configured so the signing and


### PR DESCRIPTION
The v0.0.1-rc.1 notarization dry-run failed at **Install rcodesign**: GNU tar on the Linux runner matches `*/rcodesign` literally (`tar: */rcodesign: Not found in archive`) and needs `--wildcards` to treat it as a glob. BSD tar on macOS globs by default, so this only ever fails on the CI runner — never caught locally.

The download URL itself is correct (curl succeeded). Verified the archive layout is `apple-codesign-0.27.0-.../rcodesign`, so `--strip-components=1` + `--wildcards "*/rcodesign"` is right.

Unblocks macOS signing/notarization for the v0.1.0 release. Re-validated by re-running the dry-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)