### PR TITLE
ci: zip darwin binaries before notarizing (apple rejects bare mach-o)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,11 @@ jobs:
           MACOS_CERT_PASSWORD_FILE: ${{ steps.macsign_check.outputs.enabled == 'true' && format('{0}/cert.pass', runner.temp) || '' }}
 
       # Notarize the signed darwin binaries. goreleaser leaves each built binary
-      # under dist/<id>_darwin_<arch>*/; submit each so Gatekeeper accepts them.
+      # under dist/<id>_darwin_<arch>*/. Apple's notary service only accepts
+      # containers (.zip/.dmg/.pkg/.app), not bare Mach-O executables, so each
+      # signed binary is zipped before submission. Stapling is not possible for a
+      # bare binary/zip; the submission still registers the code-signature hash
+      # with Apple so Gatekeeper accepts the extracted binary via its online check.
       - name: Notarize macOS binaries
         if: ${{ steps.macsign_check.outputs.enabled == 'true' }}
         run: |
@@ -203,10 +207,13 @@ jobs:
           shopt -s nullglob
           for bin in dist/sqi-*_darwin_*/sqi-server dist/sqi-*_darwin_*/sqi-worker; do
             echo "Notarizing $bin"
+            zippath="$RUNNER_TEMP/$(echo "$bin" | tr '/' '_').zip"
+            zip -j "$zippath" "$bin" >/dev/null
             rcodesign notary-submit \
               --api-key-file "$RUNNER_TEMP/notary-key.json" \
               --wait \
-              "$bin"
+              "$zippath"
+            rm -f "$zippath"
           done
 
       # ── Python client (sqi-sdk) distributions ──────────────────────────────


### PR DESCRIPTION
Dry-run #3: goreleaser fully succeeded (cross-compile, macOS signing, cosign, SBOMs, multi-arch Docker, GitHub release), then **Notarize** failed:

```
Error: do not know how to notarize dist/sqi-server_darwin_amd64_v1/sqi-server
```

Apple's notary service only accepts containers (`.zip`/`.dmg`/`.pkg`/`.app`), not bare Mach-O executables. Each signed binary is now zipped (`zip -j`) before `rcodesign notary-submit`. Stapling isn't possible for a bare binary/zip, but the submission registers the code-signature hash with Apple so Gatekeeper accepts the extracted binary via its online check (what the runbook's `spctl` verification relies on).

Re-validated by re-running the dry-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)