### PR TITLE
ci: raise rcodesign notarization wait limit to 30 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,9 +209,12 @@ jobs:
             echo "Notarizing $bin"
             zippath="$RUNNER_TEMP/$(echo "$bin" | tr '/' '_').zip"
             zip -j "$zippath" "$bin" >/dev/null
+            # --wait defaults to ~600s, which Apple's notary queue can exceed at
+            # busy times (submission stays "InProgress"); allow up to 30 minutes.
             rcodesign notary-submit \
               --api-key-file "$RUNNER_TEMP/notary-key.json" \
               --wait \
+              --max-wait-seconds 1800 \
               "$zippath"
             rm -f "$zippath"
           done


### PR DESCRIPTION
Dry-run #4: the zip fix worked — Apple **accepted** the upload and was processing (`InProgress`), but rcodesign's `--wait` gave up at its ~600s default:

```
reached wait limit after 602s
Error: reached time limit waiting for notarization to complete
```

Not a rejection — Apple's notary queue was just slow. Add `--max-wait-seconds 1800` so a busy queue doesn't fail the release.

Re-validated by re-running the dry-run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)