### PR TITLE
fix: duplicate websocket push on subscribe

### DIFF
--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -1130,39 +1130,31 @@ func TestWSSubscribeJobs_ScopedClientSeesOnlyOwnJobEvents(t *testing.T) {
 	// Confirm job-bob's event never arrives: a ping/pong round-trip must be
 	// the very next frame, not a second push.
 	wsWrite(t, ctx, conn, internalws.Envelope{Type: internalws.TypePing})
-
-	// Read until the pong, rejecting any push for a job alice does not own.
-	//
-	// The property under test is the one in this test's name: a scoped client
-	// must never receive another owner's event. A push for job-bob here fails
-	// the test loudly and always.
-	//
-	// A *repeat* push for job-alice does not. That is a deliberate loosening:
-	// the hub occasionally emits alice's own event twice, which made the
-	// original "the pong must be the very next frame" assertion flaky in CI
-	// (roughly 1 run in 4) while passing 350+ consecutive local iterations.
-	// Duplicate delivery of a client's own event is a correctness wart, not a
-	// confidentiality bug, and it is not what this test guards — so it is
-	// tolerated here and tracked separately rather than being allowed to mask
-	// the leak assertion behind an unrelated red build.
-	//
-	// The loop is bounded by ctx (5s) via wsRead, so a hub that never pongs
-	// still fails rather than hanging.
-	for {
-		frame := wsRead(t, ctx, conn)
-		if frame.Type == internalws.TypePong {
-			break
+	pong := wsRead(t, ctx, conn)
+	if pong.Type != internalws.TypePong {
+		// Name the job in the unexpected frame. The two ways this can fail are
+		// not equally serious and the frame type alone cannot tell them apart:
+		// a push for job-bob is a cross-owner leak — the security property this
+		// test exists to protect — whereas a second push for job-alice is a
+		// duplicate-delivery bug. The latter is what made this assertion flaky
+		// in CI until the hub stopped replaying events it had already fanned
+		// out live (see TestHub_Subscribe_NoDuplicateAcrossRegisterAndReplay).
+		// Say which one happened rather than making the next reader guess.
+		detail := ""
+		if pong.Type == internalws.TypePush && pong.Subject == internalws.SubjectJobs {
+			var unexpected internalws.JobSummaryPush
+			if err := json.Unmarshal(pong.Payload, &unexpected); err == nil {
+				switch unexpected.JobID {
+				case "job-bob":
+					detail = " — CROSS-OWNER LEAK: alice received a push for job-bob"
+				case "job-alice":
+					detail = " — duplicate push for job-alice (not a leak; the hub delivered it twice)"
+				default:
+					detail = fmt.Sprintf(" — unexpected job_id %q", unexpected.JobID)
+				}
+			}
 		}
-		if frame.Type != internalws.TypePush || frame.Subject != internalws.SubjectJobs {
-			t.Fatalf("expected TypePong or a jobs push, got type=%q subject=%q", frame.Type, frame.Subject)
-		}
-		var extra internalws.JobSummaryPush
-		if err := json.Unmarshal(frame.Payload, &extra); err != nil {
-			t.Fatalf("unmarshal unexpected push: %v", err)
-		}
-		if extra.JobID != "job-alice" {
-			t.Fatalf("CROSS-OWNER LEAK: alice received a push for job_id=%q", extra.JobID)
-		}
-		t.Logf("tolerated duplicate push for own job %q (see comment above)", extra.JobID)
+		t.Fatalf("expected TypePong (no cross-owner push queued), got type=%q subject=%q%s",
+			pong.Type, pong.Subject, detail)
 	}
 }

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -135,6 +135,19 @@ type hubClient struct {
 	id     string
 	scope  Scope
 	sendCh chan Envelope
+
+	// replayCeil is the highest ring seq per subject that this client may
+	// receive via replay, frozen when it first subscribes to that subject.
+	//
+	// It exists because registration and replay are two separate steps with a
+	// gap between them (see Subscribe). Once registered, the client receives
+	// live fan-out; anything published from that moment on must therefore NOT
+	// also be replayed, or it arrives twice. The ceiling is the ring head at
+	// registration: at-or-below it predates the subscription and is legitimate
+	// catch-up, above it was already delivered live.
+	//
+	// Guarded by Hub.mu.
+	replayCeil map[string]uint64
 }
 
 // ── subjectRing ───────────────────────────────────────────────────────────────
@@ -169,6 +182,17 @@ func (r *subjectRing) add(env Envelope) uint64 {
 		r.count++
 	}
 	return seq
+}
+
+// headSeq returns the highest seq assigned so far, or 0 when the ring is
+// empty. Used to freeze a subscriber's replay ceiling at subscribe time.
+func (r *subjectRing) headSeq() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.nextSeq == 0 {
+		return 0
+	}
+	return r.nextSeq - 1
 }
 
 // since returns all buffered envelopes with Seq strictly greater than
@@ -269,9 +293,10 @@ func (h *Hub) Register(clientID string, scope Scope) chan Envelope {
 		return existing.sendCh
 	}
 	c := &hubClient{
-		id:     clientID,
-		scope:  scope,
-		sendCh: make(chan Envelope, clientSendBuf),
+		id:         clientID,
+		scope:      scope,
+		sendCh:     make(chan Envelope, clientSendBuf),
+		replayCeil: make(map[string]uint64),
 	}
 	h.clients[clientID] = c
 	return c.sendCh
@@ -320,8 +345,17 @@ func (h *Hub) Subscribe(clientID, subject string, sinceSeq uint64) error {
 	if h.subs[subject] == nil {
 		h.subs[subject] = make(map[string]*hubClient)
 	}
-	h.subs[subject][clientID] = c
 	ring := h.ensureRingLocked(subject)
+	if _, already := h.subs[subject][clientID]; !already {
+		// First subscription to this subject. Freeze the replay ceiling at the
+		// ring's current head, in the same critical section that makes the
+		// client visible to fanout — otherwise an event published between the
+		// two would slip in above the ceiling and be both delivered live and
+		// replayed.
+		c.replayCeil[subject] = ring.headSeq()
+	}
+	h.subs[subject][clientID] = c
+	replayCeil := c.replayCeil[subject]
 	h.mu.Unlock()
 
 	// Replay outside the hub lock; ring has its own mutex. The scope check
@@ -329,6 +363,11 @@ func (h *Hub) Subscribe(clientID, subject string, sinceSeq uint64) error {
 	// without it every buffered event would bypass filtering.
 	// sinceSeq==0 replays all buffered messages; sinceSeq>0 replays from that cursor.
 	for _, env := range ring.since(sinceSeq) {
+		if env.Seq > replayCeil {
+			// Published after this client subscribed, so fanout has already
+			// delivered it live. Replaying it here is the duplicate.
+			continue
+		}
 		if !c.scope.allows(env) {
 			continue
 		}
@@ -368,6 +407,13 @@ func (h *Hub) Unsubscribe(clientID, subject string) {
 	delete(members, clientID)
 	if len(members) == 0 {
 		delete(h.subs, subject)
+	}
+	// Drop the frozen ceiling so a later re-subscribe takes a fresh one at the
+	// then-current ring head. Keeping the stale value would wrongly suppress
+	// replay of everything that arrived while the client was unsubscribed —
+	// which is exactly the catch-up replay exists for.
+	if c, ok := h.clients[clientID]; ok {
+		delete(c.replayCeil, subject)
 	}
 }
 

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -819,3 +819,101 @@ func TestHub_DiagnosticsIsValidSubject(t *testing.T) {
 		t.Fatalf("diagnostics should be a valid subject: %v", err)
 	}
 }
+
+// TestHub_Subscribe_NoDuplicateAcrossRegisterAndReplay pins the exactly-once
+// delivery boundary between live fan-out and ring replay.
+//
+// internal/api's handleSubscribe calls Subscribe TWICE by design: once with a
+// no-replay cursor to register the subscription, then — after the ack has been
+// written, so clients always see the ack before any replayed push — again with
+// the client's real since_seq to drain the ring. That split leaves a window in
+// which the client is already in h.subs (so fan-out delivers to it live) while
+// the replay has not yet run. An event published inside that window is both
+// delivered live AND appended to the ring, so the replay sends it a second
+// time.
+//
+// This is not a theoretical race. It reached production behind a default:
+// a client that omits the subscribe payload gets since_seq==0, which replays
+// the entire ring, so any event arriving during subscribe is duplicated. It
+// surfaced as a ~25% flake in the API-level owner-scoping test, where the
+// duplicate arrived where a pong was expected.
+func TestHub_Subscribe_NoDuplicateAcrossRegisterAndReplay(t *testing.T) {
+	h := newTestHub()
+	const id = "client-1"
+	ch := h.Register(id, Scope{All: true})
+
+	// Mirror handleSubscribe exactly: register with no replay...
+	const noReplaySeq = ^uint64(0)
+	if err := h.Subscribe(id, SubjectJobs, noReplaySeq); err != nil {
+		t.Fatalf("Subscribe (register): %v", err)
+	}
+
+	// ...an event lands in the window where the ack would be written...
+	h.NotifyJob(JobEvent{JobID: "job-1", Status: "running"})
+
+	// ...then the replay pass runs with the default since_seq of 0.
+	if err := h.Subscribe(id, SubjectJobs, 0); err != nil {
+		t.Fatalf("Subscribe (replay): %v", err)
+	}
+
+	var got []Envelope
+	for {
+		select {
+		case env := <-ch:
+			got = append(got, env)
+			continue
+		default:
+		}
+		break
+	}
+
+	if len(got) != 1 {
+		seqs := make([]uint64, len(got))
+		for i, e := range got {
+			seqs[i] = e.Seq
+		}
+		t.Fatalf("one NotifyJob delivered %d envelopes (seqs %v), want exactly 1: "+
+			"an event published during subscribe was sent live and then replayed", len(got), seqs)
+	}
+}
+
+// TestHub_Subscribe_ReplaysEventsPredatingSubscription is the other half of the
+// boundary: suppressing the duplicate above must not suppress genuine replay of
+// events that were already buffered when the client subscribed.
+//
+// A first client has to be subscribed for the event to reach the ring at all —
+// NotifyJob short-circuits when the subject has no subscribers and owner
+// scoping is off — so the late joiner is what exercises replay.
+func TestHub_Subscribe_ReplaysEventsPredatingSubscription(t *testing.T) {
+	h := newTestHub()
+	const noReplaySeq = ^uint64(0)
+
+	// An early subscriber, so the event is buffered.
+	h.Register("early", Scope{All: true})
+	if err := h.Subscribe("early", SubjectJobs, noReplaySeq); err != nil {
+		t.Fatalf("Subscribe (early): %v", err)
+	}
+	h.NotifyJob(JobEvent{JobID: "job-old", Status: "running"})
+
+	// A late joiner must receive it via replay.
+	late := h.Register("late", Scope{All: true})
+	if err := h.Subscribe("late", SubjectJobs, noReplaySeq); err != nil {
+		t.Fatalf("Subscribe (late, register): %v", err)
+	}
+	if err := h.Subscribe("late", SubjectJobs, 0); err != nil {
+		t.Fatalf("Subscribe (late, replay): %v", err)
+	}
+
+	select {
+	case env := <-late:
+		var push JobSummaryPush
+		if err := json.Unmarshal(env.Payload, &push); err != nil {
+			t.Fatalf("unmarshal replayed push: %v", err)
+		}
+		if push.JobID != "job-old" {
+			t.Fatalf("replayed job_id = %q, want job-old", push.JobID)
+		}
+	default:
+		t.Fatal("event buffered before the late client subscribed was not replayed")
+	}
+}


### PR DESCRIPTION
## The bug

A WebSocket client could receive the same event twice.

`internal/api/ws.go`'s `handleSubscribe` calls `hub.Subscribe` **twice** by design: once with a no-replay cursor to register the subscription, then `sendAck`, then again with the client's real `since_seq` to drain the ring. The split exists so clients always see the ack before any replayed push.

That leaves a window where the client is already in `h.subs` — so `fanout` delivers to it live — while the replay has not yet run. An event published inside that window is **both** delivered live **and** appended to the ring, so the replay sends it a second time.

It reached production behind a default: a client that omits the subscribe payload gets `since_seq: 0`, which replays the *entire* ring. The web UI subscribes exactly that way.

It surfaced as a ~25% flake in `TestWSSubscribeJobs_ScopedClientSeesOnlyOwnJobEvents` (CI only; 350+ consecutive local iterations passed), where the duplicate arrived where a pong was expected.

**Not a confidentiality bug.** Owner scoping was never bypassed — the duplicated event is always one the client was already entitled to. That was established by decoding the unexpected frame rather than assuming; see the diagnostics kept in the API test.

## Root cause, reproduced deterministically

One `NotifyJob` delivering two envelopes, `seqs [1 1]` — literally the same envelope twice, no timing dependence:

```
Subscribe(id, "jobs", noReplaySeq)   // registers; client is now live-eligible
NotifyJob(...)                        // fanout: appended to ring AND sent live
Subscribe(id, "jobs", 0)              // replay: sends it again
```

That reproduction is now `TestHub_Subscribe_NoDuplicateAcrossRegisterAndReplay`.

## The fix

`hubClient` gains a per-subject `replayCeil`, frozen to the ring head **in the same critical section** that makes the client visible to fanout. Replay skips anything above it:

- at or below the ceiling → predates the subscription → legitimate catch-up, replay it
- above the ceiling → published after registration → already delivered live, skip it

`Unsubscribe` drops the ceiling so a later re-subscribe re-freezes at the then-current head; keeping a stale value would wrongly suppress replay of everything that arrived while the client was away, which is what replay is for.

## Tests

- `TestHub_Subscribe_NoDuplicateAcrossRegisterAndReplay` — pins exactly-once delivery across the register/replay boundary.
- `TestHub_Subscribe_ReplaysEventsPredatingSubscription` — pins the other half: suppressing the duplicate must not suppress genuine catch-up. Writing this surfaced that `NotifyJob` short-circuits when a subject has no subscribers, so the test needs an early subscriber plus a late joiner.
- `TestWSSubscribeJobs_ScopedClientSeesOnlyOwnJobEvents` — **strict assertion restored.** It had been loosened on the LDAP branch to tolerate a duplicate while this bug was untriaged; that workaround is obsolete now. 300 iterations pass. The improved failure message is kept — it is what distinguished "duplicate" from "cross-owner leak" in the first place.

Both directions mutation-verified: disabling the ceiling check reproduces the duplicate; forcing `Scope.allows` open still trips the leak assertion.

`make ci` green (77.5%).
