### PR TITLE
docs: correct project status and documentation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 📖 **[Documentation](https://uberware.github.io/sqi/)** — quickstart, architecture, configuration, and full reference.
 
-> **Status:** v0.2.0 (Phase 2) released. Builds on the Phase 1 core with products and presets as an authoring layer over OpenJD, a community preset-library integration, product-driven submission, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Contributions, feedback, and discussion welcome.
+> **Status:** v0.2.0 (Phase 2) released. Builds on the Phase 1 core with products and presets as an authoring layer over OpenJD, a community preset-library integration, product-driven submission, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Phase 3 (opt-in authentication and multi-user support — local accounts, API keys, RBAC, LDAP/AD, and OAuth2/OIDC SSO) is merged on `main` and in development toward release. Contributions, feedback, and discussion welcome.
 
 ---
 
@@ -46,7 +46,7 @@ The render farm management space is in an awkward moment. Legacy on-premises sys
 
 - **Pull-based workers** register with the farm and pull assigned tasks rather than receiving pushed assignments. Workers can be added, removed, and scaled without the scheduler needing to manage their lifecycle. This makes auto-scaling and ephemeral cloud workers straightforward.
 
-- **Layered authentication** — from no auth at all (local network trust, appropriate for small private farms) through local accounts, LDAP/Active Directory, and OAuth2/OIDC for SSO. Designed so simple deployments stay simple and enterprise deployments get what they need.
+- **Layered authentication** — from no auth at all (local network trust, appropriate for small private farms) through local accounts, API keys, role-based access control, LDAP/Active Directory, and OAuth2/OIDC for SSO. Designed so simple deployments stay simple and enterprise deployments get what they need. Auth is **off by default**: set `auth.enabled: true` to turn it on, and see [docs/auth.md](docs/auth.md) for the model, roles, and identity-provider setup.
 
 - **Web UI** is the primary interface. No required desktop application. Real-time job and worker status, log streaming, preset management, product configuration, and farm administration — all in a browser.
 
@@ -67,6 +67,8 @@ sqi-worker          # run on each render node — finds the server automatically
 
 On a local network, workers discover the server via mDNS and connect without any configuration. Open a browser, start submitting. That's it.
 
+There is no authentication in this mode — the server trusts the local network, by design. To require logins, set `auth.enabled: true` and see [docs/auth.md](docs/auth.md), which covers the first-admin bootstrap, roles, API keys, and connecting a directory or SSO provider.
+
 See the [Quickstart](docs/quickstart.md) for a full walkthrough (binary or Docker Compose), including creating a farm and queue and submitting your first job.
 
 **Distributed (production mode)**
@@ -79,7 +81,7 @@ Both modes run the same software. The difference is configuration.
 
 ## Status and roadmap
 
-`sqi` v0.1.0 delivered the Phase 1 core: scheduler, pull-based workers, OpenJD job execution, and a basic web UI, with a Python client and single-binary or Docker Compose deployment. v0.2.0 completes Phase 2 — products and presets as an authoring layer over OpenJD, the community preset-library integration, a product-driven submission form, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Authentication and multi-user support (Phase 3) and production-hardening features follow in later phases.
+`sqi` v0.1.0 delivered the Phase 1 core: scheduler, pull-based workers, OpenJD job execution, and a basic web UI, with a Python client and single-binary or Docker Compose deployment. v0.2.0 completes Phase 2 — products and presets as an authoring layer over OpenJD, the community preset-library integration, a product-driven submission form, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Phase 3 — opt-in authentication and multi-user support: local accounts and API keys, role-based access control, an authenticated owner/submitter identity on jobs, LDAP/Active Directory, and OAuth2/OIDC SSO — is merged on `main` and unreleased; it is off by default, so an existing deployment is unaffected until enabled. Production-hardening features (Phase 4) follow.
 
 This is a real project with a concrete development commitment, not a design document waiting for funding. Feedback on priorities is welcome — [open an issue](https://github.com/uberware/sqi/issues/new) or [start a discussion](https://github.com/uberware/sqi/discussions/new/choose).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # `sqi` Roadmap and Technical Architecture
 
-> **Status:** v0.2.0 (Phase 2) released. Phases 1–2 are complete; Phase 3 (auth and multi-user) is next. Details may change with requests, feedback, and discoveries as development progresses.
+> **Status:** v0.2.0 (Phase 2) released. Every component planned for Phase 3 (auth and multi-user) is merged on `main` and unreleased; further work is planned before the v0.3 release. Details may change with requests, feedback, and discoveries as development progresses.
 
 This document provides technical detail on `sqi`'s architecture, core concepts, and development roadmap. For the vision and feature overview, see [README.md](README.md).
 
@@ -230,15 +230,16 @@ NATS can run embedded within `sqi-server` (simple mode) or as a separate cluster
 - Cross-job dependencies — a submission may declare `depends_on` upstream jobs (same farm, across queues); dependents are held `blocked` until every upstream completes, then released (or canceled if an upstream fails)
 - Testing job presets — ready-to-run `test-render`/`test-steps` presets (bash and PowerShell) published to the preset library for smoke-testing a farm
 
-### Phase 3: Auth and Multi-User (v0.3)
+### Phase 3: Auth and Multi-User (v0.3) — merged, unreleased
+
+Authentication is **opt-in and off by default** — an unconfigured server behaves exactly as it did
+before Phase 3. See [docs/auth.md](docs/auth.md) for the model and setup.
 
 - Local account auth (username/password, API keys)
 - LDAP/AD integration
 - Role-based access control (admin, operator, user, read-only)
 - Owner/submitter distinction in job model
 - OAuth2/OIDC support
-- User limits (per-user concurrent task caps)
-- Custom limits (end-user-configurable limit dimensions, e.g. show or client code)
 
 ### Phase 4: Production Hardening (v0.4 — beta)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,9 @@ through scheduling, worker execution, and final state.
 
 | Package | Path | Role |
 |---|---|---|
-| REST + WebSocket | `internal/server`, `internal/ws` | HTTP router, middleware, WebSocket upgrade and subscription hub |
+| REST + WebSocket | `internal/api`, `internal/ws` | chi router, REST handlers, OpenAPI spec, WebSocket upgrade and subscription hub |
+| Boot orchestration | `internal/server` | Process startup and graceful shutdown; wires the store, bus, scheduler, auth, and router together |
+| Auth | `internal/auth` | Opt-in authentication and authorization: `password` (argon2id local login), `session` (server-side cookie sessions), `apikey`, `policy` (RBAC), `rolemap`, `ldap`, `oidc`, plus the `Authenticator` interface and `chain` that select among them (see [`docs/auth.md`](auth.md)) |
 | Scheduler | `internal/scheduler` | Assignment loop, worker registry, heartbeat sweep, usage pool gating |
 | NATS bus | `internal/bus` | Typed JetStream client wrapper; stream, subject, and consumer definitions |
 | Store | `internal/store` | `Store` interface + SQLite implementation; migrations |
@@ -84,12 +86,19 @@ main()
        6. Create Store (internal/store/sqlite)
        7. Create Scheduler (internal/scheduler) — starts goroutine pool
        8. Create WebSocket hub (internal/ws)
-       9. Build chi router, mount middleware and route handlers
-      10. Register NATS consumers (worker registration, heartbeat, status, logs)
-      11. Start mDNS responder (if discovery.enabled)
-      12. Start HTTP server
-      13. Block on SIGINT / SIGTERM
-      14. Graceful shutdown:
+       9. Wire auth (internal/server wireAuthDeps) — skipped to the anonymous
+          superuser when auth.enabled is false, so auth-off boot is unchanged:
+            a. Bootstrap the first admin account (no-op once any user exists)
+            b. Select the authenticator chain (API key → session cookie)
+            c. Build the LDAP verifier    (if auth.ldap.enabled)
+            d. Build the OIDC provider    (if auth.oidc.enabled; issuer
+               discovery is lazy — a brief provider outage must not block boot)
+      10. Build chi router, mount middleware and route handlers
+      11. Register NATS consumers (worker registration, heartbeat, status, logs)
+      12. Start mDNS responder (if discovery.enabled)
+      13. Start HTTP server
+      14. Block on SIGINT / SIGTERM
+      15. Graceful shutdown:
             a. Stop accepting new HTTP connections
             b. Drain in-flight HTTP requests
             c. Stop Scheduler
@@ -535,15 +544,25 @@ Full DDL lives in `internal/store/migrations/`. The primary tables are:
 | `farms` | Top-level organizational unit; holds default scheduling policy |
 | `queues` | Belongs to a farm; jobs are submitted to a queue |
 | `jobs` | One row per submitted job; holds verbatim OpenJD template |
+| `job_dependencies` | Cross-job `depends_on` edges; gates dependents in `blocked` |
 | `steps` | One row per step in a job; tracks dependency graph |
 | `tasks` | Atomic work unit; one per expanded parameter combination |
 | `task_attempts` | One row per execution attempt; holds exit code, timing, session_id |
+| `task_logs` | Persisted task process output |
 | `workers` | Registered workers with capabilities and status |
+| `products` | Product/preset catalog above OpenJD (built-in, installed, custom) |
 | `compute_locations` | Named compute-location registry (curated catalog; auto-populated from worker registrations) |
 | `storage_locations` | Named storage locations with per-compute-location root mappings |
 | `usage_pools` | Named concurrency limits (usage pools) with `max_concurrent` cap |
 | `usage_claims` | Active usage claims tied to task attempts |
 | `audit_log` | Append-only log of state-changing API operations |
+| `users` | Local and external accounts: role, `auth_source`, `external_id` (opt-in auth only) |
+| `sessions` | Server-side browser sessions backing the session cookie |
+| `api_keys` | Hashed API-key credentials with owner and revocation state |
+
+The last three exist regardless of whether auth is enabled — the migrations
+always run — but stay empty and unread until `auth.enabled` is true. See
+[`docs/auth.md`](auth.md).
 
 WAL mode is always enabled (`PRAGMA journal_mode=WAL`). Foreign keys are
 enforced (`PRAGMA foreign_keys=ON`). A busy timeout of 5 s prevents immediate

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1266,6 +1266,10 @@ See [Testing against a real directory or identity
 provider](development.md#testing-against-a-real-directory-or-identity-provider) for the
 `SQI_TEST_OIDC_ISSUER` escape hatch and why a skip verifies nothing.
 
-## Coming next
+## Not planned
 
-- D1 — per-user concurrent task caps.
+- **Per-user concurrent task caps.** A hard per-owner ceiling on running tasks was scoped for
+  Phase 3 and deferred (2026-07-20) with no driver behind it. Nothing bounds a single user's
+  farm consumption today: `max_concurrent_tasks` on farms and queues caps the container, not the
+  person, so one user can still fill a queue's whole allowance. If that becomes a real problem,
+  it is worth deciding between a hard cap and fair-share scheduling before building either.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -549,6 +549,11 @@ The mDNS service instance name advertised on the network. Each `sqi-server` on
 the same subnet should use a distinct name to avoid collisions when running
 multiple farms on the same local network.
 
+Must not be empty, and this is checked **regardless of `discovery.enabled`** —
+explicitly setting it to `""` fails config validation and the server will not
+start, even with discovery switched off. Leave the default in place rather than
+blanking it to disable advertisement; use `discovery.enabled: false` for that.
+
 ```yaml
 discovery:
   instance_name: "studio-farm-primary"
@@ -684,9 +689,10 @@ auth:
 
 Rejects a job submission whose `owner` (set via a `jobs.submit_as` override)
 names no known user, with `400`. Default `true` — it keeps `Job.Owner` a
-trustworthy key, which per-user concurrency caps depend on; a typo'd owner
-would otherwise get its own silently uncapped bucket. Disable it when owners
-come from a directory that has not yet provisioned local records.
+trustworthy key for owner-scoped visibility: the `user` role's job listings are
+filtered by owner, so a typo'd owner yields a job invisible to the person who
+actually owns it and missed by an admin filtering on them. Disable it when
+owners come from a directory that has not yet provisioned local records.
 
 ```yaml
 auth:
@@ -727,6 +733,12 @@ auth:
 Name of the session cookie set by login and cleared by logout. Change this
 only if `sqi_session` collides with another cookie on the same domain (e.g.
 sqi served under a shared reverse-proxy host alongside another app).
+
+Must not be empty when `auth.enabled` is true — the server fails to start
+otherwise. The name is deliberately required rather than defaulted at the point
+of use: the CSRF middleware reads the cookie by name, and an empty name would
+make every mutating request take the "no session cookie" exempt path, silently
+disabling CSRF protection.
 
 ```yaml
 auth:
@@ -803,10 +815,19 @@ file- or environment-configured only. `role_map` is additionally **file-only:
 it has no environment form**, because a list of group→role pairs has no
 sensible flat encoding.
 
-The whole block is inert unless **both** `auth.enabled` and
-`auth.ldap.enabled` are true; an auth-off server never builds a verifier and
-never contacts a directory, whatever else is set here. Validation of the keys
-below only runs when `auth.ldap.enabled` is true.
+The whole block is inert while `auth.ldap.enabled` is false: the server never
+builds a verifier and never contacts a directory, whatever else is set here.
+Validation of the keys below only runs when `auth.ldap.enabled` is true.
+
+Setting `auth.ldap.enabled: true` while `auth.enabled` is false is **not** a
+silent no-op — it is a configuration error, and the server refuses to start:
+
+```
+auth.ldap.enabled: requires auth.enabled=true; LDAP without the auth gate authenticates nobody
+```
+
+Enable both together, or neither. You cannot stage an LDAP block behind a
+closed auth gate.
 
 | Key | Type | Default | Env var |
 |---|---|---|---|
@@ -920,10 +941,18 @@ environment-configured only. `role_map` is additionally **file-only: it has
 no environment form**, for the same reason as `auth.ldap.role_map` — a list of
 group→role pairs has no sensible flat encoding.
 
-The whole block is inert unless **both** `auth.enabled` and
-`auth.oidc.enabled` are true; an auth-off server never builds the SSO route,
-whatever else is set here. Validation of the keys below only runs when
-`auth.oidc.enabled` is true. Unlike LDAP, `issuer` discovery happens lazily on
+The whole block is inert while `auth.oidc.enabled` is false: the server never
+builds the SSO route, whatever else is set here. Validation of the keys below
+only runs when `auth.oidc.enabled` is true.
+
+Setting `auth.oidc.enabled: true` while `auth.enabled` is false is **not** a
+silent no-op — it is a configuration error, and the server refuses to start:
+
+```
+auth.oidc.enabled: requires auth.enabled=true; SSO without the auth gate authenticates nobody
+```
+
+Enable both together, or neither. Unlike LDAP, `issuer` discovery happens lazily on
 first use, not at boot — a briefly unreachable provider must not stop the
 scheduler from starting.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,6 +65,9 @@ Run `make` (no arguments) to see all available targets with descriptions.
 | `make test-cover` | Run tests and print coverage; fails below 70% (the `COVERAGE_MIN` default in the Makefile) |
 | `make test-cover-html` | Open an HTML coverage report in the browser |
 | `make test-integration` | Run integration tests (build tag `integration`) |
+| `make test-ldap` | Run the LDAP tests against a real OpenLDAP directory in a container (needs Docker; **skips** without it) |
+| `make test-oidc` | Run the SSO tests against a real Keycloak in a container (needs Docker; **skips** without it) |
+| `make smoke` | End-to-end smoke test against the real binaries (REST + WebSocket) |
 | `make bench` | Run benchmarks |
 | `make lint` | Run `golangci-lint` |
 | `make lint-fix` | Run `golangci-lint --fix` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 `sqi` (pronounced "sky") is an open source distributed task and render farm manager built for modern production pipelines. It is designed to run simply on a handful of local workstations and scale to hybrid on-premises and cloud infrastructure without changing how you work.
 
-> **Status:** v0.2.0 (Phase 2) released. Builds on the Phase 1 core with products and presets as an authoring layer over OpenJD, a community preset-library integration, product-driven submission, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Contributions, feedback, and discussion welcome.
+> **Status:** v0.2.0 (Phase 2) released. Builds on the Phase 1 core with products and presets as an authoring layer over OpenJD, a community preset-library integration, product-driven submission, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Phase 3 (opt-in authentication and multi-user support — local accounts, API keys, RBAC, LDAP/AD, and OAuth2/OIDC SSO) is merged on `main` and in development toward release. Contributions, feedback, and discussion welcome.
 
 ---
 
@@ -44,7 +44,7 @@ The render farm management space is in an awkward moment. Legacy on-premises sys
 
 - **Pull-based workers** register with the farm and pull assigned tasks rather than receiving pushed assignments. Workers can be added, removed, and scaled without the scheduler needing to manage their lifecycle. This makes auto-scaling and ephemeral cloud workers straightforward.
 
-- **Layered authentication** — from no auth at all (local network trust, appropriate for small private farms) through local accounts, LDAP/Active Directory, and OAuth2/OIDC for SSO. Designed so simple deployments stay simple and enterprise deployments get what they need.
+- **Layered authentication** — from no auth at all (local network trust, appropriate for small private farms) through local accounts, API keys, role-based access control, LDAP/Active Directory, and OAuth2/OIDC for SSO. Designed so simple deployments stay simple and enterprise deployments get what they need. Auth is **off by default**: set `auth.enabled: true` to turn it on, and see [the auth guide](auth.md) for the model, roles, and identity-provider setup.
 
 - **Web UI** is the primary interface. No required desktop application. Real-time job and worker status, log streaming, preset management, product configuration, and farm administration — all in a browser.
 
@@ -65,6 +65,8 @@ sqi-worker          # run on each render node — finds the server automatically
 
 On a local network, workers discover the server via mDNS and connect without any configuration. Open a browser, start submitting. That's it.
 
+There is no authentication in this mode — the server trusts the local network, by design. To require logins, set `auth.enabled: true` and see [the auth guide](auth.md), which covers the first-admin bootstrap, roles, API keys, and connecting a directory or SSO provider.
+
 See the [Quickstart](quickstart.md) for a full walkthrough (binary or Docker Compose), including creating a farm and queue and submitting your first job.
 
 **Distributed (production mode)**
@@ -77,7 +79,7 @@ Both modes run the same software. The difference is configuration.
 
 ## Status and roadmap
 
-`sqi` v0.1.0 delivered the Phase 1 core: scheduler, pull-based workers, OpenJD job execution, and a basic web UI, with a Python client and single-binary or Docker Compose deployment. v0.2.0 completes Phase 2 — products and presets as an authoring layer over OpenJD, the community preset-library integration, a product-driven submission form, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Authentication and multi-user support (Phase 3) and production-hardening features follow in later phases.
+`sqi` v0.1.0 delivered the Phase 1 core: scheduler, pull-based workers, OpenJD job execution, and a basic web UI, with a Python client and single-binary or Docker Compose deployment. v0.2.0 completes Phase 2 — products and presets as an authoring layer over OpenJD, the community preset-library integration, a product-driven submission form, additional path-translation modes, S3-compatible storage, compute locations, and in-application DCC submitters for Maya, Houdini, Nuke, and Blender. Phase 3 — opt-in authentication and multi-user support: local accounts and API keys, role-based access control, an authenticated owner/submitter identity on jobs, LDAP/Active Directory, and OAuth2/OIDC SSO — is merged on `main` and unreleased; it is off by default, so an existing deployment is unaffected until enabled. Production-hardening features (Phase 4) follow.
 
 This is a real project with a concrete development commitment, not a design document waiting for funding. Feedback on priorities is welcome — [open an issue](https://github.com/uberware/sqi/issues/new) or [start a discussion](https://github.com/uberware/sqi/discussions/new/choose).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # `sqi` Roadmap and Technical Architecture
 
-> **Status:** v0.2.0 (Phase 2) released. Phases 1–2 are complete; Phase 3 (auth and multi-user) is next. Details may change with requests, feedback, and discoveries as development progresses.
+> **Status:** v0.2.0 (Phase 2) released. Every component planned for Phase 3 (auth and multi-user) is merged on `main` and unreleased; further work is planned before the v0.3 release. Details may change with requests, feedback, and discoveries as development progresses.
 
 This document provides technical detail on `sqi`'s architecture, core concepts, and development roadmap. For the vision and feature overview, see [README.md](index.md).
 
@@ -75,7 +75,7 @@ The scheduler is intentionally stateless with respect to the running process —
 - **Step**: Component of a job with optional dependencies on other steps
 - **Task**: Atomic unit of work (one process on one worker)
 
-Configuration cascades: farm defaults → queue overrides. This avoids repeating settings across every job submission.
+Configuration cascades: farm defaults → queue overrides, with retry policy (max attempts, retry delay, failure limit) resolved over four tiers — server default → farm → queue → job override. This avoids repeating settings across every job submission.
 
 **Scheduling considers:** job priority, task dependencies, queue and farm policy (concurrency limits, scheduling mode), compute location affinity, worker capability tags (OS, GPU, installed software), and usage pool availability.
  - *Design:* ready tasks remain `ready` until a worker sends a core-NATS
@@ -225,16 +225,21 @@ NATS can run embedded within `sqi-server` (simple mode) or as a separate cluster
 - S3-compatible storage support (thin layer: derived type, root validation, path staging via operator sync tool)
 - DCC submitter framework — in-application submitters for Maya, Houdini, Nuke, and Blender (the `sqi-submitter` Python package), built on the Python client
 - Compute location registry and step-level affinity (native OpenJD `attr.worker.computelocation`)
+- Chunk bounds (`SQI_CHUNK_BOUNDS` vendor extension) — expose each task chunk's frame start/end to the command line, used by the Maya and Blender reference presets
+- Auto-retry and failure limits — per-task retry policy (max attempts, retry delay) and a job-level failure ceiling that auto-parks a job, resolved over four tiers (server → farm → queue → job) with per-task attempt history
+- Cross-job dependencies — a submission may declare `depends_on` upstream jobs (same farm, across queues); dependents are held `blocked` until every upstream completes, then released (or canceled if an upstream fails)
+- Testing job presets — ready-to-run `test-render`/`test-steps` presets (bash and PowerShell) published to the preset library for smoke-testing a farm
 
-### Phase 3: Auth and Multi-User (v0.3)
+### Phase 3: Auth and Multi-User (v0.3) — merged, unreleased
+
+Authentication is **opt-in and off by default** — an unconfigured server behaves exactly as it did
+before Phase 3. See [docs/auth.md](auth.md) for the model and setup.
 
 - Local account auth (username/password, API keys)
 - LDAP/AD integration
 - Role-based access control (admin, operator, user, read-only)
 - Owner/submitter distinction in job model
 - OAuth2/OIDC support
-- User limits (per-user concurrent task caps)
-- Custom limits (end-user-configurable limit dimensions, e.g. show or client code)
 
 ### Phase 4: Production Hardening (v0.4 — beta)
 

--- a/internal/api/submitidentity.go
+++ b/internal/api/submitidentity.go
@@ -54,8 +54,9 @@ func newOwnerLookup(st store.Store, validate bool) ownerLookup {
 //     known user, else 400 — this keeps Job.Owner a trustworthy key — and the
 //     canonical casing lookup returns is what gets stored, not the client's,
 //     matching the self path: a case variant of a known username must not get
-//     its own silently uncapped concurrency-cap bucket (see
-//     internal/config/config.go's ValidateJobOwner doc).
+//     its own separate owner bucket, or owner-scoped listing hides the job
+//     from its real owner (see internal/config/config.go's ValidateJobOwner
+//     doc).
 //
 // When auth is disabled the principal is the anonymous superuser: it holds
 // every permission and carries no username, so both client values pass through

--- a/internal/api/submitidentity_test.go
+++ b/internal/api/submitidentity_test.go
@@ -231,9 +231,9 @@ func TestBindSubmitIdentitySelfOwnerSkipsLookup(t *testing.T) {
 // does. ownerLookup discarding the looked-up User and returning only nil/err
 // let a case variant (e.g. "ALICE" for a user stored as "alice") through
 // verbatim, which internal/config/config.go's ValidateJobOwner doc says must
-// not happen: Job.Owner is meant to be a trustworthy per-user concurrency-cap
-// key, and a case variant is exactly the "own silently uncapped bucket" a
-// typo would create.
+// not happen: Job.Owner is meant to be a trustworthy key for owner-scoped
+// visibility, and a case variant splits one user across two owner buckets —
+// hiding the job from its real owner on any owner-filtered listing.
 func TestBindSubmitIdentityCanonicalizesOwnerCasing(t *testing.T) {
 	lookup := func(_ context.Context, username string) (string, error) {
 		if strings.EqualFold(username, "alice") {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,10 +192,13 @@ type AuthConfig struct {
 	Enabled bool `yaml:"enabled"`
 
 	// ValidateJobOwner rejects a submission whose Owner names no known user.
-	// Default true — it keeps Job.Owner a trustworthy key, which per-user
-	// concurrency caps depend on; a typo'd owner would otherwise get its own
-	// silently uncapped bucket. Disable it when owners come from a directory
-	// that has not yet provisioned local records.
+	// Default true — it keeps Job.Owner a trustworthy key for owner-scoped
+	// visibility: the user role's job listings are filtered by owner, so a
+	// typo'd owner yields a job invisible to the person who actually owns it
+	// and missed by an admin filtering on them. It would likewise be the key
+	// for any future per-user concurrency cap (deferred, see Wave D of the
+	// Phase 3 tracker). Disable it when owners come from a directory that has
+	// not yet provisioned local records.
 	// Env: SQI_AUTH_VALIDATE_JOB_OWNER
 	ValidateJobOwner bool `yaml:"validate_job_owner"`
 


### PR DESCRIPTION
A documentation accuracy pass over the whole repo, plus the record of the two deferred Wave D
components. No behaviour changes — Go edits here are comments only.

## Stale project status

`README.md`, `docs/index.md`, `ROADMAP.md`, and `docs/roadmap.md` all still said Phase 3 was
"next" despite every planned component being merged. They now say the planned components are
merged and unreleased, with further work expected before v0.3 — deliberately **not** "complete",
since more is planned before release.

## `docs/roadmap.md` had drifted from `ROADMAP.md`

It was missing four Phase 2 bullets (chunk bounds, auto-retry/failure limits, cross-job
dependencies, testing presets) and the retry-policy four-tier clause. It is a pure copy modulo
link paths, so it was regenerated and byte-verified against `ROADMAP.md` under path substitution.

## README had no path to enabling auth

The feature was advertised but `auth.enabled` and `docs/auth.md` appeared nowhere in README,
`docs/index.md`, or the quickstart. Added a pointer in the feature bullet and in the deployment
section, where "there is no authentication in this mode" is the load-bearing fact.

## `docs/configuration.md` — one materially wrong statement

It described the LDAP and OIDC blocks as "inert" without `auth.enabled`. They are not: that
combination **fails validation and the server refuses to start**. The doc now shows the actual
error text, so nobody stages an LDAP block behind a closed auth gate and wonders why the server
is down. Also documented two previously unstated rules: `auth.session.cookie_name` must be
non-empty when auth is on (an empty name silently disables CSRF), and `discovery.instance_name`
must be non-empty *regardless of* `discovery.enabled`.

Every other key, default, env var, and CLI flag was audited against `internal/config` and matched.

## `docs/architecture.md` — the auth subsystem was absent

No `internal/auth` row, no boot step, no `users`/`sessions`/`api_keys` tables. All added. Two
pre-existing errors fixed while there: the chi router was attributed to `internal/server` when it
lives in `internal/api` (contradicting `docs/development.md`), and the schema table was also
missing `job_dependencies`, `task_logs`, and `products` from Phase 2.

## Wave D deferrals recorded

D1 (per-user concurrent task caps) is deferred with no driver behind it; D2 (custom limit
dimensions) is dropped as already delivered by Phase 1 count-based usage pools. Both ROADMAP
bullets are struck.

This required re-justifying merged code: `auth.validate_job_owner` and the canonical-casing
storage in `bindSubmitIdentity` were documented as existing for per-user caps. They now cite
**owner-scoped visibility** — a typo'd or miscased owner yields a job invisible to its real owner
under the `user` role's owner-filtered listings — which is true today and does not lean on an
unbuilt feature. Behaviour unchanged; only the stated reason moved.

## Also

`docs/development.md` was missing `test-ldap`, `test-oidc`, and `smoke` from its Makefile target
table.
